### PR TITLE
Fix several typographic errors

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -62,7 +62,7 @@ to the terms described in the npm Dispute Resolution document.  There
 is never a good reason to be rude over package name disputes.
 
 Any spamming, trolling, flaming, baiting, or other attention-stealing
-behaviour is not welcome, and will not be tolerated.
+behavior is not welcome, and will not be tolerated.
 
 Harassing other users of the Service is never tolerated, whether via
 public or private media.
@@ -89,7 +89,7 @@ just link to the appropriate location in the Terms of Use once we have
 it.
 -->
 
-The Service administrators reserve the right to make judgement calls
+The Service administrators reserve the right to make judgment calls
 about what is and isn't appropriate in published packages.  These are
 guidelines to help you be successful in our community.
 

--- a/disputes.md
+++ b/disputes.md
@@ -29,7 +29,7 @@ ways that happens (each of these is based on actual events.)
    later, Alice finds a bug in `foo`, and fixes it.  She sends a pull
    request to Yusuf, but Yusuf doesn't have the time to deal with it,
    because he has a new job and a new baby and is focused on his new
-   erlang project, and kind of not involved with node any more.  Alice
+   Erlang project, and kind of not involved with node any more.  Alice
    would like to publish a new `foo`, but can't, because the name is
    taken.
 3. Yusuf writes a 10-line flow-control library, and calls it `foo`, and

--- a/dmca.md
+++ b/dmca.md
@@ -42,7 +42,7 @@ meeting the requirements of the DMCA, we will use good faith efforts
 to notify the complainant of such counter notice reinstate access to
 the material within 10-14 business days unless the complainant
 notifies us that it has filed a lawsuit against the allegedly
-infringing user. If we do not receive a counter notifice from such
+infringing user. If we do not receive a counter notice from such
 user within 10 business days of giving notice of the claimed
 infringement, we reserve the right to permanently delete the material
 at issue.

--- a/receiving-reports.md
+++ b/receiving-reports.md
@@ -131,7 +131,7 @@ Caveats and things to be sensitive of:
 Note that this does not mean that we will always try to accommodate
 users' wishes.  If a module name is offensive, the package contents
 are violating licenses or other intellectual property rules that could
-get us in trouble, or the package is empty (ie, squatting), or
+get us in trouble, or the package is empty (i.e., squatting), or
 otherwise violates the terms of use, we reserve the right to remove
 packages without any discussion.
 
@@ -279,7 +279,7 @@ policy. I am going to convene a meeting of a small group of people and
 figure out what our response will be."
 
 Often, the best approach is similar to handling package name disputes.
-For example, a user may be a non-native english speaker, and not
+For example, a user may be a non-native English speaker, and not
 realize that a given term is offensive.  It is our responsibility as
 the caretakers of npm to attempt to resolve this as amicably as
 possible.
@@ -418,7 +418,7 @@ When it's necessary to communicate enforcement of our policy at an
 in-person event, a brief public statement to the attendees such as
 this would suffice:
 
-"[thing] happened. This was a violation of our policy. We apologise
+"[thing] happened. This was a violation of our policy. We apologize
 for this. We have taken [action]. This is a good time for all
 attendees to review our policy at [location]. If anyone would like to
 discuss this further they can [contact us somehow]."

--- a/recruiting-process.md
+++ b/recruiting-process.md
@@ -135,7 +135,7 @@ interviews are transparent and humane. Interviews are inherently
 uncomfortable and scary, and nobody sounds smart when they are
 uncomfortable and scared. Do your best to compensate for this. If you
 think the candidate is doing well, be liberal about saying so. If the
-candidate makes a mistake, try to prevent them spiralling into
+candidate makes a mistake, try to prevent them spiraling into
 meltdown by moving on quickly or giving positive feedback about some
 other aspect of their performance.
 


### PR DESCRIPTION
Note: Some are quite nitpicky, or even border on being unnecessary: cherry-pick whatever is deemed useful!

British to American:

* `behaviour` > `behavior`;
* `apologise` > `apologize`;
* `judgement` > `judgment` (see http://grammarist.com/spelling/judgment-judgement/).

Casing:

* `erlang` > `Erlang`;
* `english` > `English`.

Miscellaneous:

* `ie` > `i.e.`;
* `notifice` > `notice`;
* `spiralling` > `spiraling` (this is a bit more vague,
  some spellcheckers highlight it, wikitionary
  mentions it too: https://en.wiktionary.org/wiki/spiral#Verb).