### PR TITLE
Break up the long list in recruiting process

### DIFF
--- a/recruiting-process.md
+++ b/recruiting-process.md
@@ -55,89 +55,6 @@ Some simple guidelines:
 We have an [open source repo](https://github.com/npm/jobs) of former
 job descriptions to help you.
 
-## Recruitment process
-
-Role is identified.
-
-Hiring Manager writes job description.
-
-As resumes come into jobs@npmjs.com (https://www.npmjs.com/jobs) and
-hiring@npmjs.com (https://www.npmjs.com/hiring), HR will upload to and
-update [Lever](https://hire.lever.co/).  It is the responsibility
-ofthe hiring manager to review resumes on a timely basis and if there
-are obvious "NO's" to let HR know immediately so the candidates can
-move forward with their job search.
-
-Everyone who speaks to a candidate must put their notes in
-[Lever](https://hire.lever.co/). The #recruitment channel on slack is
-for discussing hiring pipeline status and recruitment plans, not
-individual candidates. (i.e. it's okay to ask "is Jane coming for an
-interview?" but not "I didn't like Jane because...").
-
-1.  Post the job description.
-2.  Wait at least 2 weeks after posting a job description before
-    screening (don't screen as you go; screen as a batch).
-3.  All incoming applicants MUST be put into Lever. If you receive one
-    in your personal email account, please put into Lever and let HR
-    know. This ensures that every application gets a personal response
-    indicating we received it and a rough timeline for screening (e.g.
-    "about 1 week from now").
-5.  Hiring manager will read all available resumes and select 25-50%
-    of those candidates for first-round screening. Anybody not
-    selected is notified at this stage by HR.
-6.  First-round screening is an informal, 20-30 minute discussion, by
-    phone, Skype, or Google Hangout by the hiring manager, who will
-    select roughly 50% of these candidates for second-round screens.
-    Anybody not selected is notified at this stage by HR.
-7.  Second-round screening is 2 longer conversations, 45-60 minutes,
-    by phone or google hangout if the applicant is remote, or
-    in-person if they are local. Hiring Manager will determine which
-    prospective team-mates, or existing employees with relevant
-    skillsets will be taking part in second-round conversations. For
-    remote applicants always supply the phone number or google hangout
-    name *applicant-interviewer* in the calendar invitation. Anybody
-    not selected for this stage will be notified by HR.
-8.  After the second round interviews, hiring manager meets with
-    interviewers to select 1-3 candidates for a full team interview.
-    Often by this point there will be one obviously best candidate,
-    and it is fine to bring them in by themselves. Candidates not
-    selected for the final round are notified at this stage by HR.
-9.  Full team interview: the candidate comes in for lunch at noon (any
-    day except Monday). The hiring manager will invite 6 staff members
-    that the candidate is likely to be in contact with during their
-    day.  After lunch, anyone who hasn't yet spoken with the
-    candidate, and the hiring manager deems necessary may request a
-    30-45 minute slot.  For remote candidates after their flight,
-    hotel etc. have been arranged HR will send them their itinerary
-    and cc hiring manager, with a short "this might come in handy"
-    note containing at least one contact number for emergencies and
-    local cab or other transit options.
-10. After the full team interview, hiring manager and their team will
-    take everyone's notes into account and make a final decision.
-    After selecting the best candidate, we do *not* yet notify the
-    other candidates.
-11. Reference checks: The candidate supplies 3 names and contact
-    information of people they haveworked directly with; hiring
-    manager has a discussion with at least 2. This is a final red-flag
-    check and also gives the hiring manager a head-start on how to
-    work best with the hire.  **Questions can include** What dates did
-    the candidate work there?  What is the documented departure
-    reason?  Would you rehire?
-12. Hiring manager will consult with the selected candidate on salary,
-    benefits, relocation, visa (at the moment npm lacks the legal
-    resources to sponsor visas other than TN-1 visas for Canadian and
-    Mexican citizens), and any other issues to make sure there are no
-    unexpected barriers to a hire and a reasonable start date, and
-    make a salary recommendation to the CEO.
-13. CEO will have a final conversation with the candidate, make salary
-    offer (we will always offer the best salary we can afford, so
-    there is not much room for negotiation on salary) and discuss
-    equity. If an agreement is reached, we prepare an offer letter. If
-    not, we consider one of the other final-round candidates.
-14. Once the candidate has *signed* and we have received the offer
-    letter, HR will notify the other final round candidates.
-
-
 ## How we interview
 
 Read [Laurie's blog post on
@@ -172,6 +89,178 @@ that you know more about a topic than they do. You are not trying to
 quiz them to make sure they know everything about a specific topic or
 technology. You want to know if they can grasp complex concepts and
 explain them clearly, because that is what a knowledge worker does.
+
+## Step-by-step hiring process
+
+Role is identified.
+
+Hiring Manager writes job description.
+
+As resumes come into jobs@npmjs.com (https://www.npmjs.com/jobs) and
+hiring@npmjs.com (https://www.npmjs.com/hiring), HR will upload to and
+update [Lever](https://hire.lever.co/).  It is the responsibility
+ofthe hiring manager to review resumes on a timely basis and if there
+are obvious "NO's" to let HR know immediately so the candidates can
+move forward with their job search.
+
+Everyone who speaks to a candidate must put their notes in
+[Lever](https://hire.lever.co/). The #recruitment channel on slack is
+for discussing hiring pipeline status and recruitment plans, not
+individual candidates. (i.e. it's okay to ask "is Jane coming for an
+interview?" but not "I didn't like Jane because...").
+
+### Job Description and Initial Selection
+
+Post the job description by adding it to the [job descriptions
+repository](https://github.com/npm/job-descriptions) and the [static
+pages job
+page](https://github.com/npm/static-pages/blob/master/jobs.md).
+
+In some cases, we may choose to post the job to other locations than
+just our own website (especially for non-engineering roles, where
+skilled candidates may not be npm users).
+
+Wait at least 2 weeks after posting a job description before screening
+(don't screen as you go; screen as a batch).  This prevents us from
+unfairly privileging those who come in earlier by virtue of the fact
+that we look at them longer.
+
+All incoming applicants MUST be put into Lever. If you receive one in
+your personal email account, please put into Lever and let HR know.
+This ensures that every application gets a personal response
+indicating we received it and a rough timeline for screening (e.g.
+"about 1 week from now").
+
+Hiring manager will read all available resumes and select 25-50% of
+those candidates for first-round screening. Anybody not selected is
+notified at this stage by HR.
+
+- Did you leave the job description up for 2 weeks?
+- Did you get enough applicants to be confident that we'll find
+  someone who's a good fit?
+- Is the pool of applicants demographically diverse?  (If not,
+  this could indicate non-inclusive signals in the job description
+  that will prevent talented people from applying!)
+
+### First and Second Screen
+
+First-round screening is an informal, 20-30 minute discussion, by
+phone, Skype, or Google Hangout by the hiring manager, who will select
+roughly 50% of these candidates for second-round screens.  Anybody not
+selected is notified at this stage by HR.
+
+Second-round screening is 2 longer conversations, 45-60 minutes, by
+phone or google hangout if the applicant is remote, or in-person if
+they are local. Hiring Manager will determine which prospective
+team-mates, or existing employees with relevant skillsets will be
+taking part in second-round conversations. For remote applicants
+always supply the phone number or google hangout name
+*applicant-interviewer* in the calendar invitation. Anybody not
+selected for this stage will be notified by HR.
+
+- Did the candidate get a chance to talk to 2 members of the team?
+- Did we find people whose career goals are aligned with the needs of
+  this role?
+- Were there at least some individuals who clearly stood out from the
+  crowd?  (If not, we could be lacking clarity on the job needs, or
+  just trying to "make it work" with a pool of applicants who are all
+  not right for the role.)
+
+### Full Team Interview
+
+After the second round interviews, hiring manager meets with
+interviewers to select 1-3 candidates for a full team interview.
+
+Often by this point there will be one obviously best candidate, and it
+is fine to bring them in by themselves. Candidates not selected for
+the final round are notified at this stage by HR.
+
+Full team interview: the candidate comes in for lunch at noon (any
+day except Monday). The hiring manager will invite 6 staff members
+that the candidate is likely to be in contact with during their
+day.
+
+After lunch, anyone who hasn't yet spoken with the candidate, and the
+hiring manager deems necessary may request a 30-45 minute slot.  For
+remote candidates after their flight, hotel etc. have been arranged HR
+will send them their itinerary and cc hiring manager, with a short
+"this might come in handy" note containing at least one contact number
+for emergencies and local cab or other transit options.
+
+Important: interviewers should not discuss their reactions with other
+interviewers until *after* they've all had a chance to speak with the
+candidate.  The goal is to get everyone's authentic assessment and
+surface any concerns, not to just make the case for your personal
+favorite!  Put your own notes in lever before discussing with anyone
+else, or reading their notes.
+
+- Is the candidate eager to do this specific job?
+- Did everyone get a chance to bring up and discuss any concerns that
+  they have about the candidate or their fit with this role?
+- Is there another team that the candidate would prefer to be on?  (If
+  we think there might be, have we checked?)
+- Were there any extenuating circumstances that we should take into
+  account that might have put the candidate at a disadvantage?
+
+### Final Selection
+
+After the full team interview, hiring manager and their team will take
+everyone's notes into account and make a final decision.  After
+selecting the best candidate, we do *not* yet notify the other
+candidates.
+
+Reference checks: The candidate supplies 3 names and contact
+information of people they have worked directly with; hiring manager
+has a discussion with at least 2. This is a final red-flag check and
+also gives the hiring manager a head-start on how to work best with
+the hire.  **Questions can include** What dates did the candidate work
+there?  What is the documented departure reason?  Would you rehire?
+
+It's extremely rare that reference checking will ever uncover a
+serious dealbreaker.  It's more a gut-check to make sure that we are
+setting the employee up to succeed.
+
+Hiring manager will consult with the selected candidate on salary,
+benefits, relocation, visa (at the moment npm lacks the legal
+resources to sponsor visas other than TN-1 visas for Canadian and
+Mexican citizens), and any other issues to make sure there are no
+unexpected barriers to a hire and a reasonable start date, and make a
+salary recommendation to the CEO.
+
+- Have we identified specific reasons why this candidate is the best
+  choice for this role, moreso than other candidates who made it this
+  far?
+- Did we remember to check references, and did they bring up any
+  surprises?
+- Are we excited and eager to start working with them?
+- Can we clearly understand what they add that the company needs?
+- Is the offer fair and commensurate with other employees at the same
+  level?
+- Do we need to adjust our other open job listings now that this
+  person is part of the team?
+
+### Offer and On-Boarding
+
+CEO will have a final conversation with the candidate, make salary
+offer (we will always offer the best salary we can afford, so there is
+not much room for negotiation on salary) and discuss equity. If an
+agreement is reached, we prepare an offer letter. If not, we consider
+one of the other final-round candidates.
+
+Once the candidate has *signed* and we have received the offer letter,
+HR will notify the other final round candidates.
+
+Save signed offer and CIIAA in confidential dropbox folder.  HR works
+with new hire to get set up in TriNet, including required I9
+verification stuff.
+
+Do *not* add the new hire to GitHub, Slack, etc. until their first
+day.  Even if they are eager to get started (which we hope!), we don't
+want them doing their job until they start getting paid for it, and
+this includes stuff like "just getting acquainted with docs" or
+"lurking in chat rooms".  Those are work-time activities.  They're an
+attractive nuisance while a person is closing out their current work
+relationship and/or taking personal time between jobs.
 
 ## Changes
 


### PR DESCRIPTION
Each stage is given its own section, with brief checklist at the end.

That giant ordered-list is hard to read and keep track of, especially
when many hires are happening in parallel.