### PR TITLE
Add npm Open Source and npm Personal terms of use

### DIFF
--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -1,0 +1,371 @@
+# npm Open-Source Terms
+
+These npm Open Source terms of use (these _Terms_) govern access to
+and use of <https://www.npmjs.com> (the _Website_) as well as the
+"npm Public Registry" at <https://registry.npmjs.org> (the _Public
+Registry_). Both the Website and the Public Registry are operated by
+npm, Inc. (_npm_). The Website and the Public Registry are referred to
+together as _npm Open Source_ throughout these Terms.
+
+These npm Open Source Terms were last updated on November 9, 2015.
+
+## Important Terms
+
+***These Terms include a number of important provisions that affect your
+rights and responsibilities, such as the disclaimers in "Disclaimers",
+limits on npm's liability to you in "Limits on Liability", and an
+agreement to arbitrate disputes individually in "Arbitration".***
+
+## Other Terms
+
+npm offers additional services (_Paid Services_) that are subject to
+additional terms. Additional terms for personal private packages are
+found at <https://www.npmjs.com/policies/personal-terms>.
+
+npm Open Source and any Paid Services you may agree to use are together
+called _npm Services_ throughout these Terms.
+
+## Legal Agreement
+
+You may only access or use npm Services by agreeing to these Terms. If
+npm adds any additional functionality to npm Services, you must agree
+to these Terms to use new features, too. You show your agreement with
+npm on these Terms by clicking a check box in the process of creating an
+user account on the Website (your _Account_) or by accessing or using
+npm Services without creating an account. The agreement between you and
+npm is a legally binding contract (this _Agreement_).
+
+## Changes
+
+npm may change these Terms and the additional terms for Paid Services
+in the future. npm will post changes on the Website with a new "last
+updated" date. If you have an Account, npm will notify you of changes
+by e-mail to the address provided for your Account, by a message on the
+Website, or both. If you do not have an account, npm may notify you of
+changes by a general announcement via the Website, but it is up to you
+to check for changes to these Terms. After receiving notice of changes
+to these Terms, you must accept those changes to continue using npm
+Services. You accept changes to these Terms by continuing to use npm
+Services. npm may change, suspend, or discontinue npm Services at any
+time without notice or liability to you.
+
+## npm Policies
+
+npm respects your privacy and limits use and sharing of information
+about you collected by npm Services. The privacy policy at
+<https://www.npmjs.com/policies/privacy> (the _Privacy Policy_)
+describes these policies. npm will abide by the Privacy Policy and honor
+the privacy settings that you choose via npm Services.
+
+npm respects the exclusive rights of copyright holders and responds
+to notifications about alleged infringement via npm Services per
+the copyright policy at <https://www.npmjs.com/policies/dmca> (the
+_Copyright Policy_).
+
+npm resolves disputes about package names in the Public Registry per the
+policy at <https://www.npmjs.com/policies/disputes> (_Dispute Policy_).
+
+Use of all npm Services is governed by the code of conduct at
+<https://www.npmjs.com/policies/conduct> (_Code of Conduct_).
+
+npm permits use of npm trademarks per the policy at
+<https://www.npmjs.com/policies/trademark>.
+
+## Use of npm Open Source
+
+Subject to these Terms, npm grants you permission to use npm Open
+Source. That permission is not exclusive to you, and you cannot transfer
+it to anyone else.
+
+Your permission to use npm Open Source entitles you to do the following:
+
+1.  You may search for, download, publish, and manage packages of
+    computer code (_Packages_) in the Public Registry, and otherwise
+    interact with the Public Registry, via the command-line tool
+    published by npm at <https://www.github.com/npm/npm> (the _CLI_).
+
+2.  You may search for, download, publish, and manage Packages using
+    software other than CLI via application programming interfaces that
+    npm publicly documents or makes available for public use (_Public
+    APIs_).
+
+3.  You may search for and manage Packages in the Public Registry, and
+    otherwise interact with the Public Registry, via the Website.
+
+4.  You may update and manage your Account via the Website.
+
+## Conditions
+
+Your permission to use npm Open Source, as well as any permission you
+may have to use Paid Services, are subject to the following conditions:
+
+1.  You must be at least 13 years of age to use npm Services.
+
+2.  You may not use npm Services after npm says you may not, such as by
+    disabling your Account.
+
+3.  You must use npm Services only in accordance with "Acceptable Use".
+
+## Acceptable Use
+
+1. You will abide by the
+   [Code of Conduct](https://www.npmjs.com/policies/conduct) and the
+   [Dispute Policy](https://www.npmjs.com/policies/disputes).
+
+2.  You will not submit any content that is illegal, offensive, or
+    otherwise harmful. You will not submit any content in violation
+    of law, infringing the intellectual property rights of others,
+    violating the privacy or other rights of others, or in violation of
+    any agreement with a third party.
+
+3.  You will not disclose information that you do not have the right to
+    disclose, such as confidential information of others.
+
+4.  You will not copy or share any personally identifiable information of
+    any other person without their specific permission.
+
+5.  You will not violate any applicable law.
+
+6.  You will not use or attempt to use another person's Account without
+    their specific permission.
+
+7.  You will not send advertisements, chain letters, or other
+    solicitations via npm Services.
+
+8.  You will not automate access to, use, or monitor the Website, such
+    as with a web crawler, browser plug-in or add-on, or other computer
+    program that is not a web browser. You may replicate data from the
+    Public Registry using the Public APIs per this Agreement.
+
+9.  You will not use npm Services to send e-mail to distribution lists,
+    newsgroups, or group mail aliases.
+
+10. You will not submit material containing malicious computer code,
+    such as computer viruses, computer worms, rootkits, back doors,
+    adware, or spyware, to npm Services in such a way that you should
+    expect other users of npm Services to unwittingly execute that
+    malicious code.
+
+11. You will not falsely imply that you are affiliated with or endorsed
+    by npm.
+
+12. You will not operate illegal schemes, such as pyramid schemes, via
+    npm Services.
+
+13. You will not deep-hyperlink to images or other non-hypertext content
+    served by npm Services.
+
+14. You will not remove any marking indicating proprietary ownership
+    from any material got via npm Services.
+
+15. You will not display any portion of the Website via an HTML IFRAME.
+
+16. You will not disable, avoid, or circumvent any security or access
+    restrictions of npm Services, or access parts of npm Services not
+    intended for access by you.
+
+17. You will not strain infrastructure of npm Services with an
+    unreasonable volume of requests, or requests designed to impose an
+    unreasonable load on IT systems underlying npm Services.
+
+18. You will not encourage or assist any other person in violation of
+    "Acceptable Use".
+
+## Enforcement of Acceptable Use
+
+npm may investigate and prosecute violations of this Agreement to the
+fullest legal extent. npm may notify and cooperate with law enforcement
+authorities in prosecuting violations of this Agreement.
+
+## Your Account
+
+You must create and log into an Account to access features of some npm
+Services, including npm Open Source.
+
+To create an Account, you must provide certain information about
+yourself, as required by the account creation form on the Website. If
+you create an Account, you will provide, at a minimum, a valid e-mail
+address. You will keep that e-mail address up-to-date. You will not
+impersonate any other individual. You may delete your Account at any
+time by sending an e-mail to <support@npmjs.com>.
+
+You will be responsible for all action taken using your account, whether
+authorized by you or not, until you either close your account or give
+npm notice that the security of your Account has been compromised.
+You will notify npm immediately if you suspect the security of your
+Account has been compromised. You will select a secure password for your
+Account. You will keep your password secret.
+
+npm may restrict, suspend, or terminate your Account according to the
+Copyright Policy, if npm reasonably believes that you are in breach of
+these Terms, or if npm reasonably believes that you have misused npm
+Services.
+
+## Your Content
+
+Nothing in this Agreement gives npm any ownership rights in intellectual
+property that you share with npm Services, such as your Account
+information or any Packages you share with npm Services (_Your
+Content_). Nothing in this Agreement gives you any ownership rights in
+npm intellectual property provided via npm Services, like software,
+documentation, trademarks, service marks, logotypes, or other
+distinguishing graphics.
+
+Between you and npm, you remain solely responsible for Your Content. You
+will not wrongly imply that Your Content is sponsored or approved by
+npm. npm will not be obligated to store, maintain, or provide copies of
+your content, except per the Privacy Policy.
+
+npm may remove Your Content from npm Services without notice if npm
+suspects Your Content was submitted or used in violation of "Acceptable
+Use", as well as per the Copyright Policy.
+
+You own Your Content, but grant npm a license to use it free of charge.
+That license allows npm to do whatever it needs to do with your content,
+within reason, to provide and improve npm Services, for you and other
+users. That license lasts, for each piece of Your Content, until the
+last copy disappears from npm's backups, caches, and other systems,
+after you delete it from the Website or the Public Registry.
+
+Others who receive Your Content via npm Services may violate the terms
+on which you license Your Content. You agree that npm will not be liable
+to you for those violations or their consequences.
+
+## Feedback
+
+npm welcomes your feedback and suggestions for npm Services. You agree
+that npm will be free to act on feedback and suggestions you provide
+without further notice, consent, or payment. You will not submit
+feedback or suggestions that you consider confidential or proprietary.
+
+## Indemnity
+
+You will indemnify npm, its officers, directors, employees,
+representatives, and agents, and hold them harmless for, all liability,
+expenses, damages, and costs from any third-party claims, demands,
+lawsuits, or other proceedings alleging that Your Content, your use
+of npm Services, or both, violate the intellectual property right of
+a third party, this Agreement, or applicable law. You will not settle
+any such proceeding without the prior written consent of npm. npm will
+notify you of any such proceeding it becomes aware of.
+
+## Disclaimers
+
+***Use of npm Services is at your sole risk. npm Services are provided
+on an "as is" and "as available" basis. npm expressly disclaims all
+warranties of any kind, whether express, implied, or statutory,
+including implied warranties of title, noninfringement, merchantability,
+and fitness for a particular purpose.***
+
+***npm makes no warranty that npm Services will meet your requirements,
+operate in an uninterrupted, timely, secure, or error-free manner, or
+that errors in npm Services will be corrected.***
+
+***You receive material via npm Services at your sole risk. You will be
+solely responsible for any damage to your computer system and network,
+as well as any data loss that may result from use of npm Services or
+material received via npm Services.***
+
+npm Services may provide information and software that is inaccurate,
+incomplete, misleading, illegal, offensive, or otherwise harmful. npm
+may, but does not promise to, review content provided by npm Services.
+
+npm Services provide information about ownership and licensing of
+Packages, as provided by those Packages' publishers. That information
+may be wrong. npm cannot and does not provide legal advice.
+
+### Third-Party Services
+
+npm Services may hyperlink to and integrate with third-party
+applications, websites, and other services. You decide whether and how
+to use and interact with such services. npm does not make any warranty
+regarding such services or content they may provide, and will not be
+liable to you for any damages related to such services. Use of such
+third-party services may be governed by other terms and privacy notices
+that are not part of this Agreement and are not controlled by npm.
+
+## Limits on Liability
+
+***Neither npm nor any third-party service provider used by npm to
+provide npm Services will, under any circumstances, be liable to you
+for any indirect, incidental, consequential, special, or exemplary
+damages related to your use of npm Services or this Agreement, whether
+based on breach of contract, breach of warranty, tort (including
+negligence, product liability, or otherwise), or any other pecuniary
+loss, and whether or not npm has been advised of the possibility of such
+damages.***
+
+***To the maximum extent permitted by law, npm's liability to you for
+any damages related to this Agreement, for any one or more causes and
+regardless of the form of action, will not exceed $50.***
+
+Some jurisdictions do not allow exclusion of certain warranties or
+limits on liability for incidental or consequential damages. Some of
+"Disclaimers" and "Limits on Liability" may not apply to you.
+
+## Termination
+
+Either you or npm may terminate this Agreement at any time with notice
+to the other.
+
+On termination of this Agreement, your permission to use npm Open
+Source, as well any permission you may have to access Paid Services
+under additional terms, also terminate.
+
+The following provisions survive termination of this Agreement: "Your
+Content", "Feedback", "Indemnity", "Disclaimers", "Limits on Liability",
+and "General Terms". Users of npm Services may continue to copy and
+share Your Content after termination of this Agreement.
+
+## General Terms
+
+If a provision of this Agreement is unenforceable as written, but could
+be changed to make it enforceable, that provision should be modified to
+the minimum extent necessary to make it enforceable. Otherwise, that
+provision should be removed.
+
+You may not assign this Agreement. npm may assign this Agreement to any
+affiliate of npm, any third party that obtains control of npm, or any
+third party that purchases assets of npm relating to npm Services. Any
+purported assignment of rights in breach of this provision is void.
+
+Neither the exercise of any right under this Agreement, nor waiver of
+any breach of this Agreement, waives any other breach of this Agreement.
+
+This Agreement, together with the additional terms for Paid Services
+and npm software that you and npm agree to, embody all the terms of
+agreement between you and npm about npm Services. This Agreement
+supersedes any other agreements about npm Services, written or not.
+
+## Disputes
+
+The law of the State of California will govern any dispute, including
+any legal proceedings, relating to this Agreement or your use of npm
+Services (a _Dispute_).
+
+You and npm will seek injunctions related to this agreement only in
+state or federal court in San Francisco, California. Neither you nor npm
+will object to jurisdiction, forum, or venue in those courts.
+
+***Other than to seek an injunction, you and npm will resolve any
+Dispute by binding American Arbitration Association arbitration.
+Arbitration will follow the AAA's Commercial Arbitration Rules and
+Supplementary Procedures for Consumer Related Disputes. Arbitration will
+happen in San Francisco, California. You will settle any Dispute as an
+individual, and not as part of a class action or other representative
+proceeding, whether as the plaintiff or a class member. No arbitrator
+will consolidate any Dispute with any another arbitration without npm's
+permission.***
+
+Any arbitration award will include costs of the arbitration, reasonable
+attorneys' fees, and reasonable costs for witnesses. You or npm can
+enter arbitration awards in any court with jurisdiction.
+
+## Notices and Questions
+
+You may send notice to npm and questions about the terms governing npm
+products and services by mail to npm, Inc., Legal Department, 1999
+Harrison Street, Suite 1150, Oakland, California 94612, or by e-mail to
+<legal@npmjs.com>. npm may send you notice using the e-mail address you
+provide for your Account or by posting a message to the homepage or your
+Account page on the Website.

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -7,7 +7,9 @@ Registry_). Both the Website and the Public Registry are operated by
 npm, Inc. (_npm_). The Website and the Public Registry are referred to
 together as _npm Open Source_ throughout these Terms.
 
-These npm Open Source Terms were last updated on November 9, 2015.
+These npm Open Source Terms were last updated on
+November 9, 2015. You can review prior versions at
+<https://github.com/npm/policies/commits/master/open-source-terms.md>.
 
 ## Important Terms
 

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -20,7 +20,7 @@ agreement to arbitrate disputes individually in "Arbitration".***
 
 npm offers additional services (_Paid Services_) that are subject to
 additional terms. Additional terms for personal private packages are
-found at <https://www.npmjs.com/policies/personal-terms>.
+found at <https://www.npmjs.com/policies/private-modules-terms>.
 
 npm Open Source and any Paid Services you may agree to use are together
 called _npm Services_ throughout these Terms.

--- a/private-modules-terms.md
+++ b/private-modules-terms.md
@@ -1,0 +1,62 @@
+# npm Private Modules Terms
+
+These npm Private Modules Terms of Use (these _npm Private Modules
+Terms_) supplement the terms for npm Open Source offered by npm, Inc.
+(_npm_) at <https://www.npmjs.com/policies/open-source-terms> (_npm
+Open Source Terms_). They govern access to and use of _npm Private
+Modules_, the personal private package storage and delivery features of
+<https://www.npmjs.com> (the _Website_) and the npm public registry at
+<https://registry.npmjs.com> (the _Public Registry_).
+
+These npm Private Modules Terms were last updated on November 9, 2015.
+
+You may only access or use npm Private Modules by agreeing to the npm
+Open Source Terms as supplemented by these npm Private Modules Terms. If
+npm adds any additional functionality to npm Private Modules, you must
+agree to these npm Private Modules Terms to use those new features, too.
+You add these npm Private Modules Terms to your agreement with npm by
+clicking a check box when enabling npm Private Modules for your account
+on the Website (your _Account_). These npm Private Modules Terms then
+become a part of the contract between you and npm, until you or npm
+disable npm Private Modules for your Account.
+
+## npm Private Modules
+
+npm will provide the features and services described
+in the public documentation for npm Private Modules at
+<https://www.npmjs.com/private-modules>, and npm grants you permission
+to use those features and services. That permission isn't exclusive to
+you, and you can't transfer it or give rights to use npm Private Modules
+to others.
+
+Both your permission to use npm Private Modules and npm's commitment
+to provide npm Private Modules are subject to these npm Private
+Modules Terms, the npm Open Source Terms, and the following additional
+conditions:
+
+1.  When enabling npm Private Modules for your Account, you must provide
+    all the payment card details requested by the Website (your _Payment
+    Details_). Those details must be for a valid payment card that you
+    have the right to use (your _Payment Card_). You must keep your
+    Payment Details up-to-date via the Website.
+
+2.  You must pay $7.00 via your Payment Card when you enable npm Private
+    Modules and at the beginning of each calendar month while npm Private
+    Modules is enabled.
+
+## Billing
+
+You can disable npm Private Modules at any time via the Website. npm
+will not refund any payment you make for npm Private Modules after you
+disable npm Private Modules.
+
+When time or date matters for billing purposes under these npm Private
+Modules Terms, the relevant time and date are those in Oakland,
+California, USA.
+
+Dollar amounts in these npm Private Modules Terms are amounts of United
+States Dollars, and your payments for npm Private Modules must be
+denominated in United States Dollars.
+
+Dollar amounts in these npm Private Modules Terms do not include tax.
+You will pay any tax.

--- a/private-modules-terms.md
+++ b/private-modules-terms.md
@@ -8,7 +8,9 @@ Modules_, the personal private package storage and delivery features of
 <https://www.npmjs.com> (the _Website_) and the npm public registry at
 <https://registry.npmjs.com> (the _Public Registry_).
 
-These npm Private Modules Terms were last updated on November 9, 2015.
+These npm Private Modules Terms were last updated on
+November 9, 2015. You can review prior versions at
+<https://github.com/npm/policies/commits/master/private-modules-terms.md>.
 
 You may only access or use npm Private Modules by agreeing to the npm
 Open Source Terms as supplemented by these npm Private Modules Terms. If

--- a/terms.md
+++ b/terms.md
@@ -1,0 +1,22 @@
+# Term and Licenses
+
+npm, Inc. offers software and services under a few different licenses
+and terms of use.
+
+## Software from npm
+
+License terms and notices for the `npm` command-line program can
+be found in the LICENSE file of the project's source code at
+<https://wwww.github.com/npm/npm>.
+
+## npmjs.com and Other npm Services
+
+The [npm Open Source Terms][open-source-terms] govern all users of
+<https://www.npmjs.com> and the npm public registry.
+
+The [npm Private Modules Terms][private-terms] govern users of npm
+Private Modules.
+
+[open-source-terms]: https://www.npmjs.com/policies/open-source-terms
+
+[private-terms]: https://www.npmjs.com/policies/private-modules-terms


### PR DESCRIPTION
This PR adds:

1.  terms of use for npm Open Source

2.  additional terms of use for npm Personal, a/k/a Private Modules

3.  an index page, called "terms", that links to those new terms, plus
    CLI's license file

The npm Personal terms currently link to
<https://www.npmjs.com/private-modules> for a description of npm
Personal features. That may need to be updated once npmjs.com has new
pages describing Orgs and other offerings.