### PR TITLE
Use tools to check hyperlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 out
+html
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+---
+language: ruby
+script:
+  - "mkdir -p html"
+  - "for file in *.md ; do redcarpet --parse no_intra_emphasis --parse tables --parse autolink --parse strikethrough --parse with_toc_data $file > \"html/`basename $file .md`.html\" ; done "
+  - "htmlproof html"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+group :test do
+  gem 'redcarpet'
+  gem 'html-proofer'
+end

--- a/disputes.md
+++ b/disputes.md
@@ -3,9 +3,10 @@
 This document describes the steps that you should take to resolve module name
 disputes with other npm publishers.
 
-This document is a clarification of the acceptable behavior outlined in the [npm
-Code of Conduct](conduct), and nothing in this document should be interpreted to
-contradict any aspect of the npm Code of Conduct.
+This document is a clarification of the acceptable behavior outlined in
+the [npm Code of Conduct](https://www.npmjs.com/policies/conduct), and
+nothing in this document should be interpreted to contradict any aspect
+of the npm Code of Conduct.
 
 ## tl;dr
 
@@ -96,8 +97,8 @@ including but not limited to:
 6. Doing weird things with the registry, like using it as your own
    personal application database or otherwise putting non-packagey
    things into it.
-7. Other things forbidden by the npm [Code of
-   Conduct](conduct)
+7. Other things forbidden by the npm
+   [Code of Conduct](https://www.npmjs.com/policies/conduct)
    such as hateful language, pornographic content, or harassment.
 
 If you see bad behavior like this, please report it to <abuse@npmjs.com>

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -23,11 +23,8 @@ agreement to arbitrate disputes individually in "Arbitration".***
 npm offers additional, paid services (_Paid Services_) that are subject
 to additional terms:
 
-1. Additional terms for personal private packages are
-   available at <https://www.npmjs.com/policies/private-modules-terms>.
-
-2. Additional terms for organization private packages are
-   available at <https://www.npmjs.com/policies/orgs-terms>.
+-  Additional terms for npm Private Packages are available at
+   <https://www.npmjs.com/policies/private-terms>.
 
 npm Open Source and any Paid Services you may agree to use are together
 called _npm Services_ throughout these Terms.

--- a/recruiting-process.md
+++ b/recruiting-process.md
@@ -62,7 +62,7 @@ Role is identified.
 Hiring Manager writes job description.
 
 As resumes come into jobs@npmjs.com (https://www.npmjs.com/jobs) and
-hiring@npmjs.com (https://www.npmjs.com/hiring), HR will upload to and
+hiring@npmjs.com (https://www.npmjs.com/whoshiring), HR will upload to and
 update [Lever](https://hire.lever.co/).  It is the responsibility
 ofthe hiring manager to review resumes on a timely basis and if there
 are obvious "NO's" to let HR know immediately so the candidates can


### PR DESCRIPTION
This small PR:

1. Configures Travis CI to check policy files for broken links by rendering with redcarpet (with GitHub Flavored Markdown parsing extensions) and checking with html-proofer, both RubyGems.

2. Fixes a few broken hyperlinks in terms and policies.

You can see the build log running on my fork here: https://travis-ci.org/kemitchell/policies