### PR TITLE
Use tools to check hyperlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 out
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+---
+language: ruby
+before_script:
+  - "make"
+script:
+  - "htmlproof out"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+group :test do
+  gem 'html-proofer'
+end

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,19 @@
 mdfiles = $(wildcard *.md)
-htmlfiles = $(addprefix out/,$(mdfiles:.md=.html)) out/npm-license.html
+htmlfiles = $(addprefix out/,$(mdfiles:.md=.html))
+marked = ./node_modules/.bin/marked
 
 all: html
 
+html: $(htmlfiles)
+
+out/%.html: %.md $(marked)
+	@mkdir -p out
+	$(marked) < $< > $@
+
+$(marked):
+	npm install
+
+.PHONY: clean
+
 clean:
 	rm -rf out
-
-html: marked $(htmlfiles)
-
-# this one is special, because not markdown
-out/npm-license.html: npm-license
-	@mkdir -p out
-	echo "<pre>" > $@
-	cat $< >> $@
-	echo "</pre>" >> $@
-
-out/%.html: %.md
-	@mkdir -p out
-	node_modules/.bin/marked < $< > $@
-
-marked: node_modules/.bin/marked
-node_modules/.bin/marked:
-	npm install

--- a/disputes.md
+++ b/disputes.md
@@ -3,9 +3,10 @@
 This document describes the steps that you should take to resolve module name
 disputes with other npm publishers.
 
-This document is a clarification of the acceptable behavior outlined in the [npm
-Code of Conduct](conduct), and nothing in this document should be interpreted to
-contradict any aspect of the npm Code of Conduct.
+This document is a clarification of the acceptable behavior outlined in
+the [npm Code of Conduct](https://www.npmjs.com/policies/conduct), and
+nothing in this document should be interpreted to contradict any aspect
+of the npm Code of Conduct.
 
 ## tl;dr
 
@@ -96,8 +97,8 @@ including but not limited to:
 6. Doing weird things with the registry, like using it as your own
    personal application database or otherwise putting non-packagey
    things into it.
-7. Other things forbidden by the npm [Code of
-   Conduct](conduct)
+7. Other things forbidden by the npm
+   [Code of Conduct](https://www.npmjs.com/policies/conduct)
    such as hateful language, pornographic content, or harassment.
 
 If you see bad behavior like this, please report it to <abuse@npmjs.com>

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -23,11 +23,8 @@ agreement to arbitrate disputes individually in "Arbitration".***
 npm offers additional, paid services (_Paid Services_) that are subject
 to additional terms:
 
-1. Additional terms for personal private packages are
-   available at <https://www.npmjs.com/policies/private-modules-terms>.
-
-2. Additional terms for organization private packages are
-   available at <https://www.npmjs.com/policies/orgs-terms>.
+-  Additional terms for npm Private Packages are available at
+   <https://www.npmjs.com/policies/private-terms>.
 
 npm Open Source and any Paid Services you may agree to use are together
 called _npm Services_ throughout these Terms.

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/npm/policies/issues"
   },
-  "homepage": "https://github.com/npm/policies"
+  "homepage": "https://github.com/npm/policies",
+  "devDependencies": {
+    "marked": "^0.3.5"
+  }
 }

--- a/recruiting-process.md
+++ b/recruiting-process.md
@@ -62,7 +62,7 @@ Role is identified.
 Hiring Manager writes job description.
 
 As resumes come into jobs@npmjs.com (https://www.npmjs.com/jobs) and
-hiring@npmjs.com (https://www.npmjs.com/hiring), HR will upload to and
+hiring@npmjs.com (https://www.npmjs.com/whoshiring), HR will upload to and
 update [Lever](https://hire.lever.co/).  It is the responsibility
 ofthe hiring manager to review resumes on a timely basis and if there
 are obvious "NO's" to let HR know immediately so the candidates can


### PR DESCRIPTION
This small PR replaces #26.

It:

1. Configures Travis CI to check policy files, rendered with marked via revised `Makefile`, for broken hyperlinks with html-proofer.

2. Fixes a few broken hyperlinks.