### PR TITLE
Clarify user content license

### DIFF
--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -228,10 +228,11 @@ npm may remove Your Content from npm Services without notice if npm
 suspects Your Content was submitted or used in violation of "Acceptable
 Use", as well as per the Copyright Policy.
 
-You own Your Content, but grant npm a license to use it free of charge.
-That license allows npm to do whatever it needs to do with your content,
-within reason, to provide and improve npm Services, for you and other
-users. That license lasts, for each piece of Your Content, until the
+You own Your Content, but grant npm a free-of-charge license to provide
+Your Content to users of npm Services. That license allows npm to copy,
+publish, and process Your Content for that purpose, but does not give
+npm any additional rights to build products or services using Your
+Content. The license lasts, for each piece of Your Content, until the
 last copy disappears from npm's backups, caches, and other systems,
 after you delete it from the Website or the Public Registry.
 

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -8,7 +8,8 @@ npm, Inc. (_npm_). The Website and the Public Registry are referred to
 together as _npm Open Source_ throughout these Terms.
 
 These npm Open Source Terms were last updated on
-November 18, 2015. You can review prior versions at
+December 1, 2015.
+You can review prior versions at
 <https://github.com/npm/policies/commits/master/open-source-terms.md>.
 
 ## Important Terms

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -229,11 +229,13 @@ suspects Your Content was submitted or used in violation of "Acceptable
 Use", as well as per the Copyright Policy.
 
 You own Your Content, but grant npm a free-of-charge license to provide
-Your Content to users of npm Services. That license allows npm to copy,
-publish, and process Your Content for that purpose, but does not give
-npm any additional rights to build products or services using Your
-Content. The license lasts, for each piece of Your Content, until the
-last copy disappears from npm's backups, caches, and other systems,
+Your Content to users of npm Services. That license allows npm to make
+copies of and publish Your Content, as well as to analyze Your Content
+and share results with users of npm Services. npm may run computer code
+in Your Content to analyze it, but the license does not give npm any
+additional rights to run your code for its functionality in npm products
+or services. The license lasts, for each piece of Your Content, until
+the last copy disappears from npm's backups, caches, and other systems,
 after you delete it from the Website or the Public Registry.
 
 Others who receive Your Content via npm Services may violate the terms

--- a/organization-plan.md
+++ b/organization-plan.md
@@ -9,7 +9,8 @@ Private Packages Terms_). This Payment Plan governs payment for npm
 Private Packages organizations (_Organizations_) and use of npm Private
 Packages by user accounts added as members of those Organizations.
 
-This Payment Plan was last updated on November 18, 2015.
+This Payment Plan was last updated on
+December 1, 2015.
 You can review prior versions at
 <https://github.com/npm/policies/commits/master/personal-plan.md>.
 

--- a/personal-plan.md
+++ b/personal-plan.md
@@ -8,7 +8,8 @@ Packages_) at <https://www.npmjs.com/policies/private-terms>. This
 Payment Plan governs payment for use of npm Private Packages by a single
 user account.
 
-This Payment Plan was last updated on November 18, 2015.
+This Payment Plan was last updated on
+December 1, 2015.
 You can review prior versions at
 <https://github.com/npm/policies/commits/master/personal-plan.md>.
 

--- a/private-terms.md
+++ b/private-terms.md
@@ -10,7 +10,8 @@ the npm public registry at <https://registry.npmjs.org> (the _Public
 Registry_).
 
 These npm Private Packages Terms were last updated on
-November 18, 2015. You can review prior versions at
+December 1, 2015.
+You can review prior versions at
 <https://github.com/npm/policies/commits/master/private-terms.md>.
 
 You may only access or use npm Private Packages by agreeing to the npm


### PR DESCRIPTION
Responsive to #30, with very special thanks to @rmg

This PR refines the terms for npm Open-Source that grant npm, Inc. the license it needs to publish user content. Its purpose is to clarify our original intent: To make explicit the permission users give npm to make their content available to other users.

As a legal drafting task, this is a bit tricky, in that npm, Inc. makes lots of copies, sends them to lots of people, and also needs rights to inspect and process the contents of code packages, say to check bundledDependencies. In the future, as npm does more on the registry and website to improve install speed and package discovery, we may need to revisit this language again.

For now, however, we've had great feedback on perceived overbreadth in the opposite direction: Folks are concerned the current language might give npm, Inc. rights to "use" software in its own products and services beyond the bounds of the software license terms on which users are otherwise making their work available. This PR addresses that miscommunication head-on, hopefully without sacrificing readability.

npm, Inc. set me a clear (and rare!) design goal to make these terms as readable as possible for all npm users. We know the vast majority of users won't have counsel on call. However, we implore especially those representing commercial concerns to run this change (and the rest of the terms) past their IP lawyers. npm, Inc. has specially instructed me to take part in Issue and PRs here, but counsel should feel free to contact npm, Inc. to get in touch with me. I'll be happy to chat lawyer-to-lawyer, in the usual way, and grateful for all considered input. We want to do right by the whole npm community, both when they're hacking on the weekend and at their 9-5s.

@seldo & @isaacs: I'd like to leave this open for a day or so at least, especially if that gives @jasnell a chance to feed back. I'll plan to mention you when I think we're ready to merge (with new "last updated" date).

Quoting a previous intro in https://github.com/npm/policies/issues/30#issuecomment-159140855

> Just for the benefit of others who aren't aware: I'm legal counsel for npm, Inc. They've instructed me to do as much as I can on the terms and policies here on GitHub, as transparently as possible. That does not include giving legal advice. (Don't rely on what I say for your own purposes. Get your own lawyer and talk your needs through with them.) But it does include responding to and incorporating good feedback from the community.