### PR TITLE
Clarify trademark-based dispute procedures for user-name and org-scope disputes

### DIFF
--- a/disputes.md
+++ b/disputes.md
@@ -140,16 +140,17 @@ by a new user.
 
 ## Trademarks
 
-If you think another npm publisher is infringing your trademark, such as
-by using a confusingly similar package name, email <abuse@npmjs.com> with
-a link to the package or user account on <https://npmjs.com>.  Attach a
-copy of your trademark registration certificate.
+If you think another npm publisher is infringing your trademark,
+such as by using a confusingly similar package or user account name,
+email <abuse@npmjs.com> with a link to the package or user account
+on <https://npmjs.com>.  Attach a copy of your trademark registration
+certificate.
 
-If we see that the package's publisher is intentionally misleading others
-by misusing your registered mark without permission, we will transfer the
-package name to you.  Otherwise, we will contact the package publisher
-and ask them to clear up any confusion with changes to their package's
-`README` file or metadata.
+If we see that the user or package publisher is intentionally misleading
+others by misusing your registered mark without permission, we will
+transfer the account or package name to you.  Otherwise, we will contact
+the package publisher and ask them to clear up any confusion with changes
+to their user account page or package `README` file.
 
 Use of npm's own trademarks is covered by our Trademark Policy at
 <https://www.npmjs.com/policies/trademark>.

--- a/disputes.md
+++ b/disputes.md
@@ -140,17 +140,17 @@ by a new user.
 
 ## Trademarks
 
-If you think another npm publisher is infringing your trademark,
-such as by using a confusingly similar package or user account name,
-email <abuse@npmjs.com> with a link to the package or user account
-on <https://npmjs.com>.  Attach a copy of your trademark registration
+If you think another npm publisher is infringing your trademark, such
+as by using a confusingly similar package, org, or user account name,
+email <abuse@npmjs.com> with a link to the package, org, or user account
+page on <https://npmjs.com>.  Attach a copy of your trademark registration
 certificate.
 
-If we see that the user or package publisher is intentionally misleading
-others by misusing your registered mark without permission, we will
-transfer the account or package name to you.  Otherwise, we will contact
-the package publisher and ask them to clear up any confusion with changes
-to their user account page or package `README` file.
+If we see that the user, org, or package publisher is intentionally
+misleading others by misusing your registered mark without permission,
+we will transfer the account, org, or package name to you.  Otherwise, we
+will contact the relevant user and ask them to clear up any confusion with
+changes to their user account page, or page, or package `README` file.
 
 Use of npm's own trademarks is covered by our Trademark Policy at
 <https://www.npmjs.com/policies/trademark>.


### PR DESCRIPTION
This small PR clarifies language in the "Trademarks" section of our disputes policy, to clarify how we will handle trademark-based disputes about usernames and org names, in addition to package names.