### PR TITLE
Remove duplicated entry from the Idle domains list

### DIFF
--- a/domains.md
+++ b/domains.md
@@ -29,7 +29,6 @@ We own these but don't use them for anything (yet).
 * npm.mn
 * npm.me
 * npm.so
-* npm.tips
 
 ## Changes
 


### PR DESCRIPTION
Remove second appearance of npm.tips domain from the Idle domains list.