### PR TITLE
Remove Tab Characters

### DIFF
--- a/private-terms.md
+++ b/private-terms.md
@@ -32,16 +32,16 @@ these payment terms apply. When enabling Paid Services, you must provide
 all the payment card details requested by the Website (your _Payment
 Details_). Those details must be for a valid payment card that you have
 the right to use (your _Payment Card_). You must keep your Payment
-Details up-to-date via the Website.		
+Details up-to-date via the Website.
 
-You can disable Paid Services at any time via the Website. npm will not		
-refund any payment you have already made for Paid Services when you		
-disable Paid Services.		
+You can disable Paid Services at any time via the Website. npm will not
+refund any payment you have already made for Paid Services when you
+disable Paid Services.
 
-Dollar amounts throughout this Agreement are amounts of United States		
-Dollars. You must pay for Paid Services in United States Dollars.		
+Dollar amounts throughout this Agreement are amounts of United States
+Dollars. You must pay for Paid Services in United States Dollars.
 
-Dollar amounts throughout this Agreement do not include tax. You will		
+Dollar amounts throughout this Agreement do not include tax. You will
 pay any tax.
 
 ## Use of npm Paid Services

--- a/trademark.md
+++ b/trademark.md
@@ -45,10 +45,10 @@ npm projects.
 
 At npm, Inc. we do three things to support this goal:
 
-1.	Run the open source registry as a free service.
-2.	Build tools and operate services that support the secure use of
+1.  Run the open source registry as a free service.
+2.  Build tools and operate services that support the secure use of
     packages in a private or enterprise context.
-3.	Build innovative new tools and services for the developer
+3.  Build innovative new tools and services for the developer
     community.
 
 ## Why npm, Inc. has a trademark policy


### PR DESCRIPTION
This PR removes tab characters from Markdown files, both for consistency, and to avoid rendering break tags in paragraphs where the tabs appeared at the ends of plain-text lines.