### PR TITLE
terms: Add notes reminding not to share paid accounts

### DIFF
--- a/organization-plan.md
+++ b/organization-plan.md
@@ -10,7 +10,7 @@ Paid Services Terms_). This Payment Plan governs payment for
 accounts added as members of those Organizations.
 
 This Payment Plan was last updated on
-June 27, 2017.
+June 15, 2018.
 You can review prior versions at
 <https://github.com/npm/policies/commits/master/organization-plan.md>.
 
@@ -23,3 +23,8 @@ entitles you to a single member of the organization (a _New Paid Services
 User_). You will pay $7.00 via your Payment Card per each additional
 New Paid Services User that you add to an Organization, counted and
 billed on your Billing Day.
+
+Note that the npm Paid Services Terms require everyone using npm Paid
+Services to have an Account of their own, added under a Payment Plan.
+You must add a New Paid Services User to an Organization for each
+person who will use npm Paid Services under this Payment Plan.

--- a/personal-plan.md
+++ b/personal-plan.md
@@ -9,7 +9,7 @@ Services Terms_). This Payment Plan governs payment for use of
 npm Solo by a single user account.
 
 This Payment Plan was last updated on
-June 27, 2017.
+June 15, 2018.
 You can review prior versions at
 <https://github.com/npm/policies/commits/master/personal-plan.md>.
 
@@ -17,3 +17,8 @@ You will pay $7.00 via your Payment Card when you enable npm Solo
 for your Account by selecting this Payment Plan, and thereafter
 on the same day every month while this Payment Plan remains
 selected for your Account.
+
+Note that the npm Paid Services Terms require everyone using npm Paid
+Services to have an Account of their own, added under a Payment Plan.
+You may not allow anyone else to use npm Paid Services under this
+Payment Plan.


### PR DESCRIPTION
@seldo, this small patch adds parallel reminders to our Orgs and Personal payments plans that accounts belong to single users, and every person using paid services needs an account under a payment plan.

I've updated the dates on the payment plans, but these changes shouldn't affect the meaning of the terms.  The only additions are pointers back to other terms, from which customers should already understand they need _n_ accounts in an org for _n_ people, and can't share a Personal Plan by sharing credentials.