### PR TITLE
Address npm.community

### DIFF
--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -3,9 +3,10 @@
 These npm Open Source terms of use (these _Terms_) govern access to
 and use of <https://www.npmjs.com> (the _Website_) as well as the
 "npm Public Registry" at <https://registry.npmjs.org> (the _Public
-Registry_). npm, Inc. (_npm_) operates both the Website and
-the Public Registry. These terms refer to the Website and
-the Public Registry together as _npm Open Source_.
+Registry_), and the discussion forum at <https://npm.community>
+(_npm.community_). npm, Inc. (_npm_) operates each of those
+services. These terms refer to all of them together as _npm Open
+Source_.
 
 npm last updated these npm Open Source Terms on
 August 6, 2018.
@@ -100,6 +101,9 @@ Your permission to use npm Open Source entitles you to do the following:
     otherwise interact with the Public Registry, via the Website.
 
 4.  You may update and manage your Account via the Website.
+
+5.  You may visit, create an account for, and participate in,
+    discussions on npm.community.
 
 ## Conditions
 
@@ -266,7 +270,7 @@ its analyses with others. npm may run computer code in Your Content to
 analyze it, but npm's special license alone does not give npm the right
 to run code for its functionality in npm products or services.
 
-When Your Content is removed from the Website or the Public Registry,
+When Your Content is removed from npm Services,
 whether by you or npm, npm's special license ends when the last copy
 disappears from npm's backups, caches, and other systems. Other
 licenses, such as open source licenses, may continue after Your Content

--- a/privacy.md
+++ b/privacy.md
@@ -326,7 +326,7 @@ npm stores correspondence as long as it may be useful for these purposes.
 
 ### <a id="forum-data">npm collects data about use of npm.community.</a>
 
-npm collects data about visits, user accounts, and forum data on [npm.community](https://npm.community), the discussion forum for npm products and services.  npm uses data from npm.community to collaborate with the development community, and to inform development decisions about the command-line interface and other software.
+npm collects data about visits, user accounts, and forum data on [npm.community](https://npm.community), the discussion forum for users of npm products and services.  npm uses data from npm.community to collaborate with the development community, and to inform development decisions about the command-line interface and other software.
 
 Civilized Discourse Construction Kit, Inc. hosts [npm.community](https://npm.community) for npm.  For more information on CDCK, and a link to their privacy notice, see [the section on CDCK below](#cdck).
 

--- a/privacy.md
+++ b/privacy.md
@@ -59,6 +59,8 @@ npm collects data about you:
 
 - when you send support, privacy, legal, and other requests to npm
 
+- when you visit [npm.community](https://npm.community)
+
 - when working with and researching current and potential customers
 
 When researching potential customers, npm staff sometimes search the
@@ -322,6 +324,12 @@ npm uses contact data to:
 
 npm stores correspondence as long as it may be useful for these purposes.
 
+### <a id="forum-data">npm collects data about use of npm.community.</a>
+
+npm collects data about visits, user accounts, and forum data on [npm.community](https://npm.community), the discussion forum for npm command-line interface development.  npm uses data from npm.community to collaborate with the development community, and to inform development decisions about the command-line interface and other software.
+
+Civilized Discourse Construction Kit, Inc. hosts [npm.community](https://npm.community) for npm.  For more information on CDCK, and a link to their privacy notice, see [the section on CDCK below](#cdck).
+
 ## <a id="choice">How can I make choices about data collection?</a>
 
 You choose what data the `npm publish` command includes in package data. 
@@ -358,6 +366,8 @@ customers' choosing.
 npm distributes package data published to the npm public registry and
 metadata about those packages worldwide, via
 [content delivery networks](#cdns).
+
+Data for [npm-community](https://npm.community) is hosted and stored by Civilized Discourse Construction Kit, Inc., which hosts the forum for npm.  For more information on CDCK, and a link to their privacy notice, see [the section on CDCK below](#cdck).
 
 ### <a id="privacy-shield">npm participates in the Privacy Shields.</a>
 
@@ -410,6 +420,8 @@ by accessing the appropriate [registry's API](https://github.com/npm/registry/tr
 Registry APIs provide metadata in standard [JSON](https://www.json.org)
 format, and packages as [tarballs](https://en.wikipedia.org/wiki/Tar_(computing)).
 
+The [privacy policy for Discourse](#cdck) describes how you can access data about you stored for [npm.community](https://npm.community).
+
 ## <a id="change">How can I change or erase data about me?</a>
 
 You can change your personal account data and payment card data at any
@@ -446,6 +458,8 @@ distribution, and use of package data indefinitely.  Nearly all popular
 open source software licenses actually require preserving personal data
 that attributes the software to you, such as copyright notices, as a
 condition of permission for the software.
+
+The [privacy policy for Discourse](#cdck) describes how you can change or erase data about you stored for [npm.community](https://npm.community).
 
 ## <a id="forgotten">Does the right to be forgotten cover unpublishing packages?</a>
 
@@ -496,6 +510,8 @@ If you think your package has been wrongly blocked or erased,
 [email support@npmjs.com](mailto:support@npmjs.com) to reach an npm team
 member who can review the decision.
 
+The [privacy policy for Discourse](#cdck) describes automated decisions on [npm.community](https://npm.community).
+
 ## <a id="sharing">Does npm share data about me with others?</a>
 
 npm shares account data with others as
@@ -503,6 +519,8 @@ npm shares account data with others as
 
 npm shares package data with others as
 [mentioned in the section about package data](#package-data).
+
+npm publishes posts and other content you submit to [npm.community](https://npm.community).
 
 npm does not sell information about you to others.  However, npm uses
 services provided by other companies to provide npm services.  Some of
@@ -597,6 +615,10 @@ as track who reads and follows links in those messages.  You can read
 
 npm uses [Slack](https://slack.com) for internal communication.  You can read
 [the privacy policy for Slack online](https://slack.com/privacy).
+
+### <a id="cdck">npm uses Civilized Discourse Construction Kit for npm.community.</a>
+
+npm uses [CDCK](https://discourse.com) to host [npm.community](https://npm.community), the discussion forum for npm command-line interface development.  You can read [CDCK's privacy policy online](https://www.discourse.org/privacy).
 
 ## <a id="contact">Who can I contact about npm and my privacy?</a>
 

--- a/privacy.md
+++ b/privacy.md
@@ -326,7 +326,7 @@ npm stores correspondence as long as it may be useful for these purposes.
 
 ### <a id="forum-data">npm collects data about use of npm.community.</a>
 
-npm collects data about visits, user accounts, and forum data on [npm.community](https://npm.community), the discussion forum for npm command-line interface development.  npm uses data from npm.community to collaborate with the development community, and to inform development decisions about the command-line interface and other software.
+npm collects data about visits, user accounts, and forum data on [npm.community](https://npm.community), the discussion forum for npm products and services.  npm uses data from npm.community to collaborate with the development community, and to inform development decisions about the command-line interface and other software.
 
 Civilized Discourse Construction Kit, Inc. hosts [npm.community](https://npm.community) for npm.  For more information on CDCK, and a link to their privacy notice, see [the section on CDCK below](#cdck).
 

--- a/terms.md
+++ b/terms.md
@@ -11,7 +11,8 @@ be found in the LICENSE file of the project's source code at
 
 ## Free to use npm services
 
-Free usage of <https://www.npmjs.com> and the npm public registry
+Free usage of <https://www.npmjs.com>, the npm public registry,
+and <https://npm.community>
 are covered by the npm Open Source Terms at <https://www.npmjs.com/policies/open-source-terms>.
 These terms include several important policies, including:
 


### PR DESCRIPTION
This WIP PR revises the privacy policy and Open Source terms to cover and address [npm.community](https://npm.community).  I will need to take at least one more pass.

cc @zkat, @iarna