### PR TITLE
Fix republish time window

### DIFF
--- a/unpublish.md
+++ b/unpublish.md
@@ -16,7 +16,7 @@ If the package is still within the first 72 hours, you should use one of the fol
 Some considerations:
 
 -  Once `package@version` has been used, you can never use it again. You must publish a new version even if you unpublished the old one
-- If you entirely unpublish a package, nobody else (even you) will be able to publish a package of that name for 72 hours.
+- If you entirely unpublish a package, nobody else (even you) will be able to publish a package of that name for 24 hours.
 
 ## What to do if your package was published more than 72 hours ago
 


### PR DESCRIPTION
Updates the republish time window to 24 hours. (It was incorrectly changed to 72 hours.)