### PR TITLE
Smyte -> Sift

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -499,7 +499,7 @@ npm public registry that published data has been erased:
 
 ## <a id="decisions">Does npm make automated decisions based on data about me?</a>
 
-npm uses data in packages and data about how you use the registry to
+npm uses data in packages and data about how you use npm software and the public registry to
 make decisions about whether the packages you publish are spam, promote
 scams, abuse others, or otherwise violate our
 [terms of service](https://www.npmjs.com/policies/terms).

--- a/privacy.md
+++ b/privacy.md
@@ -503,7 +503,7 @@ npm uses data in packages and data about how you use the registry to
 make decisions about whether the packages you publish are spam, promote
 scams, abuse others, or otherwise violate our
 [terms of service](https://www.npmjs.com/policies/terms).
-When [Smyte](#smyte) decides that a package is likely in violation, npm
+When [Sift Science](#sift) decides that a package is likely in violation, npm
 blocks publishing the package or erases the package.
 
 If you think your package has been wrongly blocked or erased,
@@ -575,13 +575,12 @@ npm uses [Google Cloud Platform](https://cloud.google.com/) to host
 some npm Enterprise registries.  You can read [the privacy policy for
 Google services online](https://policies.google.com/privacy?hl=en&gl=us).
 
-### <a id="smyte">npm uses Smyte.</a>
+### <a id="sift">npm uses Sift Science.</a>
 
-npm uses [Smyte](https://www.smyte.com/) to detect packages that are
+npm uses [Sift Science](https://siftscience.com/) to detect packages that are
 spam, promote scams, abuse others, or otherwise violate our
 [terms of service](https://www.npmjs.com/policies/terms).  You can read
-[the privacy policy for Smyte online by following the link at the
-bottom of their homepage](https://www.smyte.com/).
+[the privacy policy for Sift Science online](https://siftscience.com/service-privacy).
 
 ### <a id="stripe">npm uses Stripe.</a>
 


### PR DESCRIPTION
This PR updates parts of our privacy policy to reflect our transition from Smyte to Sift Science for automated spam and abuse prevention.