### PR TITLE
Update npm mailing address

### DIFF
--- a/dmca.md
+++ b/dmca.md
@@ -128,9 +128,8 @@ Send all takedown notices and counter notices to:
 
 Kyle Mitchell  
 c/o npm, Inc.  
-1999 Harrison Street, Suite 1150  
-Oakland, CA 94612  
-copyright@npmjs.com  
-+1 (510) 907 - 3049
+2500 Venture Oaks Way, Suite 390  
+Sacramento, CA 95833  
++1 (510) 907-3049
 
 Send via email for fastest processing.

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -495,8 +495,8 @@ enter arbitration awards in any court with jurisdiction.
 ## Notices and Questions
 
 You may send notice to npm and questions about the terms governing npm
-products and services by mail to npm, Inc., Legal Department, 1999
-Harrison Street, Suite 1150, Oakland, California 94612, or by email to
+products and services by mail to npm, Inc., Legal Department, 
+2500 Venture Oaks Way, Suite 390 Sacramento, CA 95833, or by email to
 <legal@npmjs.com>. npm may send you notice using the email address you
 provide for your Account or by posting a message to the homepage or your
 Account page on the Website.

--- a/privacy.md
+++ b/privacy.md
@@ -652,9 +652,9 @@ You can send questions or complaints to:
 npm, Inc.  
 Attention: Data Protection Officer  
 [privacy@npmjs.com](mailto:privacy@npmjs.com)  
-1999 Harrison Street \#1150  
-Oakland, CA 94612  
-United States of America
+2500 Venture Oaks Way, Suite 390  
+Sacramento, CA 95833  
++1 (510) 907-3049
 
 European Union users with questions or complaints about GDPR compliance
 should also address npm's representative in the Union:


### PR DESCRIPTION
# What / Why

The mailing address on our dmca, privacy policy, and open source terms pages is out of date.

(It's our old Oakland office.)

## References
https://npm-inc.slack.com/archives/C025CG2D2/p1588091003053700