### PR TITLE
Update contact information

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@
 These are the legal policies of npm, Inc.
 
 <ul>
-<li><a href="https://www.npmjs.com/policies/terms">Terms of Use</a></li>
-<li><a href="https://www.npmjs.com/policies/conduct">Code of Conduct</a></li>
-<li><a href="https://www.npmjs.com/policies/disputes">Package Name Disputes</a></li>
-<li><a href="https://www.npmjs.com/policies/npm-license">npm License</a></li>
-<li><a href="https://www.npmjs.com/policies/privacy">Privacy Policy</a></li>
-<li><a href="https://www.npmjs.com/policies/unpublish">Unpublish Policy</a></li>
-<li><a href="https://www.npmjs.com/policies/receiving-reports">Receiving Abuse Reports</a></li>
-<li><a href="https://www.npmjs.com/policies/dmca">Copyright and DMCA Policy</a></li>
-<li><a href="https://www.npmjs.com/policies/trademark">Trademark Policy</a></li>
-<li><a href="https://www.npmjs.com/policies/security">Security</a></li>
-<li><a href="https://www.npmjs.com/policies/recruiting-process">Recruiting Process</a></li>
-<li><a href="https://www.npmjs.com/policies/crawlers">Replication and web crawler policy</a></li>
-<li><a href="https://www.npmjs.com/policies/domains">Our official list of domains</a></li>
-<li><a href="https://www.npmjs.com/what-is-npm">What is npm?</a></li>
+<li><a href="/policies/terms">Terms of Use</a></li>
+<li><a href="/policies/conduct">Code of Conduct</a></li>
+<li><a href="/policies/disputes">Package Name Disputes</a></li>
+<li><a href="/policies/npm-license">npm License</a></li>
+<li><a href="/policies/privacy">Privacy Policy</a></li>
+<li><a href="/policies/unpublish">Unpublish Policy</a></li>
+<li><a href="/policies/receiving-reports">Receiving Abuse Reports</a></li>
+<li><a href="/policies/dmca">Copyright and DMCA Policy</a></li>
+<li><a href="/policies/trademark">Trademark Policy</a></li>
+<li><a href="/policies/security">Security</a></li>
+<li><a href="/policies/recruiting-process">Recruiting Process</a></li>
+<li><a href="/policies/crawlers">Replication and web crawler policy</a></li>
+<li><a href="/policies/domains">Our official list of domains</a></li>
+<li><a href="/what-is-npm">What is npm?</a></li>
 </ul>
 
 These are updated from time to time.  Their sources are stored in a git

--- a/dmca.md
+++ b/dmca.md
@@ -126,10 +126,19 @@ we removed.
 
 Send all takedown notices and counter notices to:
 
-Kyle Mitchell  
-c/o npm, Inc.  
-2500 Venture Oaks Way, Suite 390  
-Sacramento, CA 95833  
-+1 (510) 907-3049
+You can also send an email notification to
+[copyright@npmjs.com](mailto:copyright@npmjs.com). You may include an
+attachment if you like, but please also include a plain-text version of
+your letter in the body of your message.
 
-Send via email for fastest processing.
+If you must send your notice by physical mail, you can do that too, but
+it will take substantially longer for us to receive and respond to it.
+Notices we receive via plain-text email have a much faster turnaround
+than PDF attachments or physical mail. If you still wish to mail us
+your notice, our physical address is:
+
+GitHub, Inc
+Attn: DMCA Agent
+88 Colin P Kelly Jr St
+San Francisco, CA. 94107
+

--- a/dmca.md
+++ b/dmca.md
@@ -137,8 +137,7 @@ Notices we receive via plain-text email have a much faster turnaround
 than PDF attachments or physical mail. If you still wish to mail us
 your notice, our physical address is:
 
-GitHub, Inc
-Attn: DMCA Agent
-88 Colin P Kelly Jr St
+GitHub, Inc  
+Attn: DMCA Agent  
+88 Colin P Kelly Jr St  
 San Francisco, CA. 94107
-

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -495,8 +495,14 @@ enter arbitration awards in any court with jurisdiction.
 ## Notices and Questions
 
 You may send notice to npm and questions about the terms governing npm
-products and services by mail to npm, Inc., Legal Department, 
-2500 Venture Oaks Way, Suite 390 Sacramento, CA 95833, or by email to
-<legal@npmjs.com>. npm may send you notice using the email address you
-provide for your Account or by posting a message to the homepage or your
-Account page on the Website.
+products and services to [legal@npmjs.com](mailto:legal@npmjs.com) or
+by mail to:
+
+GitHub, Inc
+Attn: npm Legal Department
+88 Colin P Kelly Jr St
+San Francisco, CA. 94107
+
+npm may send you notice using the email address you provide for your
+Account or by posting a message to the homepage or your Account page
+on the Website.

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -498,9 +498,9 @@ You may send notice to npm and questions about the terms governing npm
 products and services to [legal@npmjs.com](mailto:legal@npmjs.com) or
 by mail to:
 
-GitHub, Inc
-Attn: npm Legal Department
-88 Colin P Kelly Jr St
+GitHub, Inc  
+Attn: npm Legal Department  
+88 Colin P Kelly Jr St  
 San Francisco, CA. 94107
 
 npm may send you notice using the email address you provide for your

--- a/privacy.md
+++ b/privacy.md
@@ -646,30 +646,28 @@ than the age of 16, we will delete that information.
 
 ## <a id="contact">Who can I contact about npm and my privacy?</a>
 
+You may email us directly at [privacy@npmjs.com](mailto:privacy@npmjs.com)
+with the subject line "Privacy Concerns."  You may also contact our Data
+Protection Officer directly.
 
-You can send questions or complaints to:
+Our United States HQ:
 
-npm, Inc.  
-Attention: Data Protection Officer  
-[privacy@npmjs.com](mailto:privacy@npmjs.com)  
-2500 Venture Oaks Way, Suite 390  
-Sacramento, CA 95833  
-+1 (510) 907-3049
+GitHub Data Protection Officer
+Attention: npm Data Protection
+8 Colin P. Kelly Jr. St.
+San Francisco, CA 94107
+United States
 
-European Union users with questions or complaints about GDPR compliance
-should also address npm's representative in the Union:
+or our EU Office:
 
-DP-Dock GmbH  
-[npm@gdpr-rep.com](mailto:npm@gdpr-rep.com)  
-Ballindamm 39  
-20095 Hamburg  
-Germany  
-Telephone: +49 (0) 40 99999 - 3430  
-Mobile: +49 (0) 172 918 22 22
+GitHub BV
+Vijzelstraat 68-72
+1017 HL Amsterdam
+The Netherlands
 
 ## <a id="changes">How can I find out about changes?</a>
 
-This version of npm's privacy questions and answers took effect April 1, 2020.
+This version of npm's privacy questions and answers took effect June 3, 2020.
 
 npm will announce the next version on the [npm blog](https://blog.npmjs.org/). 
 In the meantime, npm may update [its contact information](#contact)

--- a/privacy.md
+++ b/privacy.md
@@ -654,7 +654,7 @@ Our United States HQ:
 
 GitHub Data Protection Officer  
 Attention: npm Data Protection  
-8 Colin P. Kelly Jr. St.  
+88 Colin P. Kelly Jr. St.  
 San Francisco, CA 94107  
 United States
 

--- a/privacy.md
+++ b/privacy.md
@@ -408,9 +408,9 @@ your data as outlined in this section.
 
 npm respects privacy rights under [Regulation (EU) 2016/679](http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.L_.2016.119.01.0001.01.ENG),
 the European Union's General Data Protection Regulation (GDPR). npm
-processes "Personal Data" on the following legal bases: (1) with your
-consent; (2) as necessary to perform our agreement to provide our
-services; and (3) as necessary for our legitimate interests in providing
+processes "Personal Data" on the following legal bases: (1) with your
+consent; (2) as necessary to perform our agreement to provide our
+services; and (3) as necessary for our legitimate interests in providing
 our services where those interests do not override your fundamental
 rights and freedom related to data privacy. Information we collect may
 be transferred to, and stored and processed in, the United States or any
@@ -652,17 +652,17 @@ Protection Officer directly.
 
 Our United States HQ:
 
-GitHub Data Protection Officer
-Attention: npm Data Protection
-8 Colin P. Kelly Jr. St.
-San Francisco, CA 94107
+GitHub Data Protection Officer  
+Attention: npm Data Protection  
+8 Colin P. Kelly Jr. St.  
+San Francisco, CA 94107  
 United States
 
 or our EU Office:
 
-GitHub BV
-Vijzelstraat 68-72
-1017 HL Amsterdam
+GitHub BV  
+Vijzelstraat 68-72  
+1017 HL Amsterdam  
 The Netherlands
 
 ## <a id="changes">How can I find out about changes?</a>


### PR DESCRIPTION
Update the physical addresses for contacting us in all our policy documentation.  In each case, the legal and privacy contacts are now GitHub, Inc.