### PR TITLE
Update support contact to be the new support website

### DIFF
--- a/business-solution-terms.md
+++ b/business-solution-terms.md
@@ -80,7 +80,7 @@ _npm_ agrees to take industry-standard security precautions to defend _Customer'
 
 #### Technical Support
 
-_npm_ agrees to task _npm_ **Support Personnel** with responding to **Technical Support Requests** from _Customer Personnel_. If _Customer's Solution_ is _npm Enterprise_, _Technical Support Requests_ must be e-mailed to enterprise@npmjs.com. If _Customer's Solution_ is _npm Orgs_, _Technical Support Requests_ must be e-mailed to support@npmjs.com.
+_npm_ agrees to task _npm_ **Support Personnel** with responding to **Technical Support Requests** from _Customer Personnel_. _Technical Support Requests_ must be opened at https://npmjs.com/support/.
 
 #### Scope of Technical Support
 

--- a/conduct.md
+++ b/conduct.md
@@ -97,9 +97,9 @@ rules will be deleted, at the discretion of npm.
 Please select the method of contact you think is most appropriate for
 the form of violation:
 
-* For urgent security issues, contact <security@npmjs.com>. Requests to
-  reset lost passwords are best handled by <support@npmjs.com>. Requests
-  to un-publish packages are not usually considered urgent security
+* For urgent security issues, contact <security@npmjs.com>. Note that
+  reset lost passwords are best handled by https://npmjs.com/support.
+  Requests to un-publish packages are not usually considered urgent security
   issues, as it is possible to [un-publish a package](https://docs.npmjs.com/cli/unpublish)
   within 24 hours of its first publish. Any publicly published package
   is [immediately replicated to thousands of third-party mirrors](http://blog.npmjs.org/post/101934969510/oh-no-i-accidentally-published-private-data-to),
@@ -120,7 +120,7 @@ the form of violation:
   follow the process described in the
   [Disputes Policy](https://www.npmjs.com/policies/disputes).
 
-For any other issues, or if in doubt, contact <support@npmjs.com>.
+For any other issues, or if in doubt, [contact support](https://npmjs.com/support).
 
 
 ## Consequences

--- a/disputes.md
+++ b/disputes.md
@@ -13,8 +13,11 @@ of the npm Code of Conduct or Open-Source Terms.
 ## tl;dr
 
 1. Get the author email with `npm owner ls <pkgname>`
-2. Email the author, CC <support@npmjs.com>
-3. After 4 weeks, if there's no resolution, we'll address it.
+2. Open a support ticket at https://npmjs.com/support
+3. Reply to the support ticket email, adding the author on the `To`
+   line so that both npm support and the author are now on the thread.
+4. Politely ask if the author will transfer the package.
+5. After 4 weeks, if there's no resolution, we'll address it.
 
 Don't squat on package names, user names or organization names.
 Publish code or move out of the way.
@@ -51,30 +54,44 @@ To dispute a package called `foo`, follow these steps:
 
 1. Run `npm owner ls foo`.  This will give you the email address of
    an owner of `foo` (there may be more than one valid owner).
-2. Send a message to that email address, explaining the situation
-   **as respectfully as possible**, as well as what you would like
-   to see happen. Add <support@npmjs.com> to the CC list of the email.
-   If you would like to be given control of the package, mention
-   in the email that the current owner can run
-   `npm owner add <yourusername> foo` to do so.
-3. After 4 weeks, if the owner has not responded, support will address your request. The ultimate outcome is at their discretion and judgement.
+2. Open a support ticket at https://npmjs.com/support, indicating that
+   you would like to start the process to request ownership of the `foo`
+   package.  You will get an automated reply from npm support to your
+   email address.
+3. Reply to that automated email, and add the package owner that you
+   identified in the first step to the To line of the email.  Now,
+   you, npm support and the package owner are all on the email conversation.
+4. Explain the situation to the package owner **as respectfully as possible**,
+   as well as what you would like to see happen.
+   If you would like to be given control of the package, mention in the
+   email that the current owner can run `npm owner add <yourusername> foo`
+   to do so.
+3. After 4 weeks, if the owner has not responded, support will address your
+   request. The ultimate outcome is at their discretion and judgement.
 
 ### Organizations
 
 To dispute an organization name, follow these steps:
 
-1. Contact support@npmjs.com with the name of the organization, e.g. `@foo`.
+1. Open a support ticket at https://npmjs.com/support, indicating that
+   you dispute an organization name.  Include the name of the organization,
+   e.g. `@foo`.
 2. Support will contact the organization owner on your behalf requesting
    the transfer. They may at their discretion include you in this dialogue.
-3. After 4 weeks, if the owner has not responded, support will address your request. The ultimate outcome is at their discretion and judgement.
+3. After 4 weeks, if the owner has not responded, support will address
+   your request. The ultimate outcome is at their discretion and judgement.
 
 ### User names
 
 To dispute a user name, follow these steps:
 
-1. Contact support@npmjs.com with the name of the user account, e.g. `@foo`
-2. Support will contact the user account owner on your behalf requesting the transfer. They may at their discretion include you in this dialogue.
-3. After 4 weeks, if the owner has not responded, support will address your request. The ultimate outcome is at their discretion and judgement.
+1. Open a support ticket at https://npmjs.com/support, indicating that
+   you dispute a user name.  Include the name of the user account,
+   e.g. `@foo`.
+2. Support will contact the user account owner on your behalf requesting
+   the transfer. They may at their discretion include you in this dialogue.
+3. After 4 weeks, if the owner has not responded, support will address
+   your request. The ultimate outcome is at their discretion and judgement.
 
 
 ## Reasoning
@@ -124,9 +141,9 @@ an organization has private packages, so a paid organization will
 never be considered squatted.
 
 Unlike users, organizations do not have an "owner" or published
-email address. If you believe an organization is squatted, email
-<support@npmjs.com> directly and we will make the determination 
-on your behalf.
+email address. If you believe an organization is squatted,
+[contact support](https://npmjs.com/support) directly and we will
+make the determination on your behalf.
 
 ### User names
 

--- a/npm-license.md
+++ b/npm-license.md
@@ -243,10 +243,9 @@ agreement.  By using npm, you acknowledge your agreement to all such policies
 and restrictions.
 
 If you have a complaint about a package in the public npm registry, and cannot
-resolve it with the package owner, please email support@npmjs.com and explain
-the situation.  See the [npm Dispute Resolution
-policy](https://github.com/npm/policies/blob/master/disputes.md) for more
-details.
+resolve it with the package owner, please
+[contact support](https://npmjs.com/support) and explain the situation.
+See the [npm Dispute Resolution policy](https://github.com/npm/policies/blob/master/disputes.md) for more details.
 
 Any data published to The npm Registry (including user account information) may
 be removed or modified at the sole discretion of the npm server administrators.

--- a/open-source-terms.md
+++ b/open-source-terms.md
@@ -304,7 +304,7 @@ yourself, as required by the account creation form on the Website or the
 CLI. If you create an Account, you will provide, at a minimum, a valid
 email address. You will keep that email address up-to-date. You will
 not impersonate any other individual. You may delete your Account at any
-time by sending an email to <support@npmjs.com>.
+time by [contacting support](https://npmjs.com/support).
 
 You will be responsible for all action taken using your account, whether
 authorized by you or not, until you either close your account or give

--- a/privacy.md
+++ b/privacy.md
@@ -566,11 +566,10 @@ format, and packages as
 You can change your personal account data and payment card data at any
 time by visiting your account settings page on
 [www.npmjs.com](https://www.npmjs.com/). You can change
-account and payment data for Enterprise by [emailing
-support@npmjs.com](mailto:support@npmjs.com).
+account and payment data for Enterprise by [contacting support](https://npmjs.com/support).
 
 You can close your npm account at any time by e-mailing
-[support@npmjs.com](mailto:support@npmjs.com). Closing
+[contacting support](https://npmjs.com/support).  Closing
 your account removes the profile from the public registry but does not
 automatically erase packages published under your account. We may retain
 some data about you internally even where you close your account.

--- a/receiving-reports.md
+++ b/receiving-reports.md
@@ -27,11 +27,14 @@ encourage things to continue in that direction.
 The policy in brief, where "Alice" is the original author, and "Yusuf"
 is the person with the dispute:
 
-1. Yusuf emails Alice, explaining the reasons for wanting the module
-   name, and CC's npm support.
-2. We set a timer for 4 weeks.  If that lands on a holiday or
+1. Yusuf opens a support ticket, indicating that they would like to
+   start the trasnfer process.
+2. Yusuf responds to the automated email that we generate for new
+   support tickets, and adds Alice to the email thread.  Yusuf explains
+   why they would want to transfer the module name.
+3. We set a timer for 4 weeks.  If that lands on a holiday or
    something, err on the side of making the delay longer.
-3. At this point, one of three things have happened:
+4. At this point, one of three things have happened:
 
     a. Alice and Yusuf have resolved the situation in a way that works
     for both of them.
@@ -89,8 +92,9 @@ leaving an abandoned module in npm, then do this:
         latest Node versions, whatever], so I'd like to hand it off to
         Yusuf to take over.
 
-        If this causes you any stress or inconvenience, please let me
-        know as soon as possible.
+        We'll hand this package over to Yusuf in one week.  Please let
+        us know if you intend to publish functional code before this
+        time.
 
 2. Set a timer for 1 week.
 3. If Alice responds with concerns, then use diplomacy.  Usually this
@@ -169,9 +173,8 @@ an email asking them to please stop the bad behavior.
 Here's an example:
 
     Subject: Empty/duplicate packages removed
-    From: Isaac Schlueter <isaacs@npmjs.com>
+    From: npm support <support@npmjs.com>
     To: Some User <some-user@gmail.com>
-    Cc: npm support <support@npmjs.com>
 
     Several empty and duplicated packages belonging to you were
     removed.

--- a/security.md
+++ b/security.md
@@ -27,7 +27,7 @@ react appropriately to security threats when they arise.
 
 If you need to report a security vulnerability.  Please email
 [security@npmjs.com](mailto:security@npmjs.com). If your issue 
-is specific to your account, such as lost credentials, contacting [support@npmjs.com](mailto:support@npmjs.com) is more appropriate.
+is specific to your account, such as lost credentials, contacting [our support team](https://npmjs.com/support) is more appropriate.
 
 We review all security reports on the next business day.  Note that
 the npm staff is generally offline for most US holidays, but please do

--- a/unpublish.md
+++ b/unpublish.md
@@ -52,7 +52,7 @@ This document is additive to the [unpublish procedures](https://docs.npmjs.com/u
 
 ## Issues?
 
-If for some reason your package meets the unpublish policy criteria but the unpublish command fails, or if you need assistance with the deprecate process, please reach to support@npmjs.com where we'll be happy to assist.
+If for some reason your package meets the unpublish policy criteria but the unpublish command fails, or if you need assistance with the deprecate process, please [reach out to our support team](https://npmjs.com/support) where we'll be happy to assist.
 
 If you believe a package violates npm's terms or policies, such as our terms of use, [reach out to our support team](https://www.npmjs.com/support).  If a package infringes your copyright, [refer to npm's DMCA takedown policy](https://www.npmjs.com/policies/dmca).  If you believe a package violates your privacy rights, [contact our privacy team](https://www.npmjs.com/policies/privacy#contact) as soon as possible.
 


### PR DESCRIPTION
npm now has a single point of entry for receiving support requests:
https://npmjs.com/support.  npm no longer accepts new support tickets
via email.

By having a single point of entry into our support channel, we can
provide more efficient support.  In particular, by using a form on the
website, we can gather additional information up-front, to respond to
support requests more quickly.

The policy documents are updated to reflect the new mechanism for
contacting support.  This is a change to the mechanisms of contacting
support, and not a change to the way in which you report problems or
receive support.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
