### PR TITLE
Revert "Fixed all the broken links in README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ These are the legal policies of npm, Inc.
 <li><a href="/policies/security">Security</a></li>
 <li><a href="/policies/crawlers">Replication and web crawler policy</a></li>
 <li><a href="/policies/domains">Our official list of domains</a></li>
-<li><a href="/what-is-npm">What is npm?</a></li>
 </ul>
 
 These are updated from time to time.  Their sources are stored in a git

--- a/README.md
+++ b/README.md
@@ -3,18 +3,19 @@
 These are the legal policies of npm, Inc.
 
 <ul>
-<li><a href="/terms.md">Terms of Use</a></li>
-<li><a href="/conduct.md">Code of Conduct</a></li>
-<li><a href="/disputes.md">Package Name Disputes</a></li>
-<li><a href="/npm-license.md">npm License</a></li>
-<li><a href="/privacy.md">Privacy Policy</a></li>
-<li><a href="/unpublish.md">Unpublish Policy</a></li>
-<li><a href="/receiving-reports.md">Receiving Abuse Reports</a></li>
-<li><a href="/dmca.md">Copyright and DMCA Policy</a></li>
-<li><a href="/trademark.md">Trademark Policy</a></li>
-<li><a href="/security.md">Security</a></li>
-<li><a href="/crawlers.md">Replication and web crawler policy</a></li>
-<li><a href="/domains.md">Our official list of domains</a></li>
+<li><a href="/policies/terms">Terms of Use</a></li>
+<li><a href="/policies/conduct">Code of Conduct</a></li>
+<li><a href="/policies/disputes">Package Name Disputes</a></li>
+<li><a href="/policies/npm-license">npm License</a></li>
+<li><a href="/policies/privacy">Privacy Policy</a></li>
+<li><a href="/policies/unpublish">Unpublish Policy</a></li>
+<li><a href="/policies/receiving-reports">Receiving Abuse Reports</a></li>
+<li><a href="/policies/dmca">Copyright and DMCA Policy</a></li>
+<li><a href="/policies/trademark">Trademark Policy</a></li>
+<li><a href="/policies/security">Security</a></li>
+<li><a href="/policies/crawlers">Replication and web crawler policy</a></li>
+<li><a href="/policies/domains">Our official list of domains</a></li>
+<li><a href="/what-is-npm">What is npm?</a></li>
 </ul>
 
 These are updated from time to time.  Their sources are stored in a git


### PR DESCRIPTION
Reverts npm/policies#147

These pages are built for our website and checked in to this repository for visibility and traceability. But that means that the links are formatted for our website at https://www.npmjs.com/policies. Changing them so that they're useful in the context of this repository - at the moment - breaks the links on our website.

Obviously it would be nice if they were consistent and usable in both places, but the tooling does not do this at the moment. I'm reverting this to fix the website.