### PR TITLE
tools: fix broken links in README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ marked = ./node_modules/.bin/marked
 all: html
 
 html: $(htmlfiles)
-	
 
 out/%.html: %.md $(marked)
 	@mkdir -p out

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,14 @@ marked = ./node_modules/.bin/marked
 all: html
 
 html: $(htmlfiles)
+	
 
 out/%.html: %.md $(marked)
 	@mkdir -p out
 	$(marked) < $< > $@
+	@if [ $< = "README.md" ]; then\
+		sed -i '' -e 's#href="/#href="/policies/#g' -e 's/.md//g' $@;\
+	fi
 
 $(marked):
 	npm install

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 These are the legal policies of npm, Inc.
 
 <ul>
-<li><a href="/policies/terms">Terms of Use</a></li>
-<li><a href="/policies/conduct">Code of Conduct</a></li>
-<li><a href="/policies/disputes">Package Name Disputes</a></li>
-<li><a href="/policies/npm-license">npm License</a></li>
-<li><a href="/policies/privacy">Privacy Policy</a></li>
-<li><a href="/policies/unpublish">Unpublish Policy</a></li>
-<li><a href="/policies/receiving-reports">Receiving Abuse Reports</a></li>
-<li><a href="/policies/dmca">Copyright and DMCA Policy</a></li>
-<li><a href="/policies/trademark">Trademark Policy</a></li>
-<li><a href="/policies/security">Security</a></li>
-<li><a href="/policies/crawlers">Replication and web crawler policy</a></li>
-<li><a href="/policies/domains">Our official list of domains</a></li>
+<li><a href="/terms.md">Terms of Use</a></li>
+<li><a href="/conduct.md">Code of Conduct</a></li>
+<li><a href="/disputes.md">Package Name Disputes</a></li>
+<li><a href="/npm-license.md">npm License</a></li>
+<li><a href="/privacy.md">Privacy Policy</a></li>
+<li><a href="/unpublish.md">Unpublish Policy</a></li>
+<li><a href="/receiving-reports.md">Receiving Abuse Reports</a></li>
+<li><a href="/dmca.md">Copyright and DMCA Policy</a></li>
+<li><a href="/trademark.md">Trademark Policy</a></li>
+<li><a href="/security.md">Security</a></li>
+<li><a href="/crawlers.md">Replication and web crawler policy</a></li>
+<li><a href="/domains.md">Our official list of domains</a></li>
 </ul>
 
 These are updated from time to time.  Their sources are stored in a git


### PR DESCRIPTION
Added a bit of sed to the makefile to append "/policies" where
appropriate in README.md

The result is that the links now work on GitHub and on the website.

Refs: https://github.com/npm/policies/pull/150
Fixes: https://github.com/npm/policies/issues/146