### PR TITLE
docs: archive repostiory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,3 @@
 # policies
 
-These are the legal policies of npm, Inc.
-
-<ul>
-<li><a href="/policies/terms">Terms of Use</a></li>
-<li><a href="/policies/conduct">Code of Conduct</a></li>
-<li><a href="/policies/disputes">Package Name Disputes</a></li>
-<li><a href="/policies/npm-license">npm License</a></li>
-<li><a href="/policies/privacy">Privacy Policy</a></li>
-<li><a href="/policies/unpublish">Unpublish Policy</a></li>
-<li><a href="/policies/receiving-reports">Receiving Abuse Reports</a></li>
-<li><a href="/policies/dmca">Copyright and DMCA Policy</a></li>
-<li><a href="/policies/trademark">Trademark Policy</a></li>
-<li><a href="/policies/security">Security</a></li>
-<li><a href="/policies/crawlers">Replication and web crawler policy</a></li>
-<li><a href="/policies/domains">Our official list of domains</a></li>
-</ul>
-
-These are updated from time to time.  Their sources are stored in a git
-repository at <https://github.com/npm/policies>.
+This Repostiory is now Archived. Our current policies can be found at https://github.com/npm/documentation/tree/main/content/policies

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # policies
 
-This Repostiory is now Archived. Our current policies can be found at https://github.com/npm/documentation/tree/main/content/policies
+This Repository is now Archived. Our current policies can be found at https://github.com/npm/documentation/tree/main/content/policies


### PR DESCRIPTION
policies now live at https://github.com/npm/documentation/tree/main/content/policies